### PR TITLE
Detect return types for loadTemplate

### DIFF
--- a/src/twig/Node_ClassEnd.php
+++ b/src/twig/Node_ClassEnd.php
@@ -4,6 +4,8 @@ namespace ttempleton\nocache\twig;
 
 use Twig\Compiler;
 use Twig\Node\Node as TwigNode;
+use Composer\Semver\VersionParser;
+use Composer\InstalledVersions;
 
 /**
  * Class Node_ClassEnd
@@ -31,9 +33,21 @@ class Node_ClassEnd extends TwigNode
      */
     public function compile(Compiler $compiler): void
     {
+        /**
+         * twig/twig 3.13 added return types to Twig\Template::loadTemplate
+         * which causes errors when you're on a newer version of twig
+         *
+         * https://github.com/twigphp/Twig/blob/v3.13.0/src/Template.php#L280
+         */
+        if (InstalledVersions::satisfies(new VersionParser(), 'twig/twig', "^3.13")) {
+            $returnTypes = ': Twig\Template|Twig\TemplateWrapper';
+        } else {
+            $returnTypes = '';
+        }
+
         $compiler
             ->raw(PHP_EOL)
-            ->write('protected function loadTemplate($template, $templateName = null, $line = null, $index = null)' . PHP_EOL)
+            ->write('protected function loadTemplate($template, $templateName = null, $line = null, $index = null)' . $returnTypes . PHP_EOL)
             ->write('{' . PHP_EOL)
             ->indent()
                 // If $template === $this->getTemplateName(), then Twig will assume the No-Cache template is the correct


### PR DESCRIPTION
Sorry I closed that other one because it was broken! This one actually works.

In v3.13, twig added return types to Twig\Template::loadTemplate which means these compiled templates are now causing a fatal error as return types do not match.

```
[12-Sep-2024 11:08:12 Europe/London] PHP Fatal error:  Declaration of __NoCacheTemplate_5f6bd2a72cc2224f57c80f43e9cbe428703aaa597fe072886dca8c72454a61fb::loadTemplate($template, $templateName = null, $line = null, $index = null) must be compatible with Twig\Template::loadTemplate($template, $templateName = null, $line = null, $index = null): Twig\Template|Twig\TemplateWrapper in /app/storage/runtime/compiled_templates/nocache/nocache_5f6bd2a72cc2224f57c80f43e9cbe428703aaa597fe072886dca8c72454a61fb.php on line 75
```

This detects whether your installed version has these return types and either tags on the return type or doesn't. This felt like the least destructive way to do this. We're using your plugin quite a lot so would appreciate a merge on this, or implementation of something better that does the same thing!

Thank you!